### PR TITLE
Rename page local variable.

### DIFF
--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -1,23 +1,23 @@
 When(/^a user provides their details$/) do
-  page = Pages::NewUserProfile.new
-  page.load
+  profile = Pages::NewUserProfile.new
+  profile.load
 
-  page.name.set('Joe Bloggs')
-  page.age.set(55)
-  page.email.set('joe.bloggs@example.com')
-  page.retirement_preference_6_months.set(true)
-  page.pension_type_defined_contribution.set(true)
-  page.channel_preference_phone.set(true)
-  page.channel_preference_web.set(true)
-  page.wishlist.set('Some reassurance and a clearer understanding of my options.')
-  page.submit.click
+  profile.name.set('Joe Bloggs')
+  profile.age.set(55)
+  profile.email.set('joe.bloggs@example.com')
+  profile.retirement_preference_6_months.set(true)
+  profile.pension_type_defined_contribution.set(true)
+  profile.channel_preference_phone.set(true)
+  profile.channel_preference_web.set(true)
+  profile.wishlist.set('Some reassurance and a clearer understanding of my options.')
+  profile.submit.click
 end
 
 Then(/^they are shown a thank you message$/) do
-  page = Pages::UserProfile.new
+  profile = Pages::UserProfile.new
 
-  expect(page).to be_displayed
-  expect(page).to have_heading(text: /^Thank you$/)
+  expect(profile).to be_displayed
+  expect(profile).to have_heading(text: /^Thank you$/)
 end
 
 Then(/^they are captured and saved$/) do


### PR DESCRIPTION
`page` is defined in `Capybara::DSL` as a method to access the current session.
See: http://www.rubydoc.info/github/jnicklas/capybara/Capybara/DSL:page
