### PR TITLE
Remove slimmer

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-GOVUK_APP_DOMAIN=gov.uk
-PLEK_SERVICE_STATIC_URI=assets.digital.cabinet-office.gov.uk

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,12 @@ source 'https://rubygems.org'
 ruby '2.1.4'
 
 gem 'govuk_frontend_toolkit'
-gem 'meta-tags'
+gem 'govuk_template'
 gem 'rails', '4.1.7'
 gem 'sass-rails', '~> 4.0.3'
-gem 'slimmer', '~> 5.0'
-gem 'uglifier', '>= 1.3.0'
 gem 'sequel', '~> 4.0'
 gem 'sqlite3'
+gem 'uglifier', '>= 1.3.0'
 gem 'unicorn'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,23 +60,20 @@ GEM
     govuk_frontend_toolkit (1.7.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
+    govuk_template (0.10.1)
+      rails (>= 3.1)
     hike (1.2.3)
     i18n (0.6.11)
     json (1.8.1)
     kgio (2.9.2)
     mail (2.6.1)
       mime-types (>= 1.16, < 3)
-    meta-tags (2.0.0)
-      actionpack (>= 3.0.0)
     method_source (0.8.2)
     mime-types (2.4.3)
     minitest (5.4.2)
     multi_json (1.10.1)
     multi_test (0.1.1)
-    netrc (0.8.0)
     nokogiri (1.5.11)
-    null_logger (0.0.1)
-    plek (1.9.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -103,9 +100,6 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (10.3.2)
-    rest-client (1.7.2)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rspec-core (3.0.4)
       rspec-support (~> 3.0.0)
     rspec-expectations (3.0.4)
@@ -132,14 +126,6 @@ GEM
     site_prism (2.6)
       addressable (~> 2.3.3)
       capybara (>= 2.1, < 3.0)
-    slimmer (5.0.0)
-      activesupport
-      json
-      nokogiri (~> 1.5.0)
-      null_logger
-      plek (>= 0.1.8)
-      rack (>= 1.3.5)
-      rest-client
     slop (3.6.0)
     spring (1.1.3)
     spring-commands-cucumber (1.0.1)
@@ -178,14 +164,13 @@ DEPENDENCIES
   cucumber-rails
   dotenv-rails
   govuk_frontend_toolkit
-  meta-tags
+  govuk_template
   pry-rails
   rails (= 4.1.7)
   rspec-rails (~> 3.0.0)
   sass-rails (~> 4.0.3)
   sequel (~> 4.0)
   site_prism
-  slimmer (~> 5.0)
   spring
   spring-commands-cucumber
   spring-commands-rspec

--- a/app/assets/stylesheets/register-your-interest.css.scss
+++ b/app/assets/stylesheets/register-your-interest.css.scss
@@ -10,10 +10,6 @@
 @import "elements/panels";
 @import "elements/icons";
 
-.site-width-container {
-  @extend %site-width-container;
-}
-
 .new_user_profile {
   input[type="text"] {
     margin:0;
@@ -22,8 +18,11 @@
   }
 }
 
-.alpha-label {
-  @include media(tablet){
-    margin: 0 30px;
+.l-page-container {
+  @extend %site-width-container;
+  @extend %contain-floats;
+  padding-bottom: $gutter;
+  @include media(desktop) {
+    padding-bottom: $gutter*3;
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,5 @@
 class ApplicationController < ActionController::Base
   include Authentication
-  include Slimmer::Headers
 
   protect_from_forgery with: :exception
-
-  before_filter do
-    set_slimmer_headers(alpha_label: "before:#global-breadcrumb ol")
-  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,24 +1,42 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <%= display_meta_tags site: 'GOV.UK', separator: '-', reverse: true %>
+<% content_for :head do %>
   <!--[if gt IE 8]><!--><%= stylesheet_link_tag 'register-your-interest', media: 'all' %><!--<![endif]-->
   <!--[if IE 6]><%= stylesheet_link_tag 'register-your-interest-ie6', media: 'all' %><![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag 'register-your-interest-ie7', media: 'all' %><![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag 'register-your-interest-ie8', media: 'all' %><![endif]-->
-  <%= csrf_meta_tags %>
-</head>
-<body>
+<% end %>
 
-<div id="wrapper">
-  <main id="content" role="main">
-    <div class="site-width-container">
-      <%= yield %>
+<% content_for :header_class, 'with-proposition' %>
+
+<% content_for :proposition_header do %>
+  <div class="header-proposition">
+    <div class="content">
+        <a href="/" id="proposition-name">Pension Guidance Service</a>
     </div>
-  </main>
-</div>
+  </div>
+<% end %>
 
-<%= javascript_include_tag 'register-your-interest' %>
+<% content_for :content do %>
+  <div class="l-page-container">
+    <div class="phase-banner">
+      <p>
+        <strong class="phase-tag">ALPHA</strong>
+        <span>This is a new service – your
+          <a href="mailto:pensions-alpha-feedback@digital.cabinet-office.gov.uk?Subject=Feedback%20for%20Pension%20Guidance%20Alpha%20Service">
+            feedback</a> will help us to improve it.
+        </span>
+      </p>
+    </div>
 
-</body>
-</html>
+    <div class="l-grid-row">
+      <div class="l-column-two-thirds">
+        <main role="main" id="content" tabindex="-1">
+          <article role="article" class="govspeak">
+            <%= yield %>
+          </article>
+        </main>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<%= render template: 'layouts/govuk_template' %>

--- a/app/views/user_profiles/confirmation.html.erb
+++ b/app/views/user_profiles/confirmation.html.erb
@@ -1,7 +1,9 @@
-<h1 class="heading-xlarge"><%= title 'Thank you' %></h1>
+<% content_for :page_title, 'Thank you for your interest in pension guidance - GOV.UK' %>
 
-<p>Thank you for your interest in the Guidance Guarantee.</p>
+<div class="text">
+  <h1 class="heading-xlarge">Thank you for your interest</h1>
 
-<p>We will email you with more details in the near future.</p>
+  <p>We will email you with more details in the near future.</p>
 
-<p>Do not reply to suspicious emails. Our service will never ask you for your bank details or to buy a product.</p>
+  <p>Do not reply to suspicious emails. Our service will never ask you for your bank details or to buy a product.</p>
+</div>

--- a/app/views/user_profiles/new.html.erb
+++ b/app/views/user_profiles/new.html.erb
@@ -1,6 +1,8 @@
-<h1 class="heading-xlarge"><%= title 'Register your interest' %></h1>
+<% content_for :page_title, 'Register your interest in pension guidance - GOV.UK' %>
 
 <div class="text">
+  <h1 class="heading-xlarge">Register your interest in pension guidance</h1>
+
   <p>The government is creating a new service to help people understand what they can do with their pension pots
     before they retire.</p>
 

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -17,7 +17,7 @@ Then(/^they are shown a thank you message$/) do
   profile = Pages::UserProfile.new
 
   expect(profile).to be_displayed
-  expect(profile).to have_heading(text: /^Thank you$/)
+  expect(profile).to have_heading(text: /^Thank you for your interest$/)
 end
 
 Then(/^they are captured and saved$/) do


### PR DESCRIPTION
Updates layout inline with the GOV.UK Service Manual.

Includes some additional tweaks to content to improve page titles and warn about the risk of scam.
