### PR TITLE
Add error pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby '2.1.5'
 
+gem 'gaffe'
 gem 'govuk_frontend_toolkit'
 gem 'govuk_template'
 gem 'rails', '4.1.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
     foreman (0.63.0)
       dotenv (>= 0.7)
       thor (>= 0.13.6)
+    gaffe (1.0.2)
+      rails (>= 3.2.0)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     govuk_frontend_toolkit (1.7.0)
@@ -172,6 +174,7 @@ DEPENDENCIES
   cucumber-rails
   dotenv-rails
   foreman
+  gaffe
   govuk_frontend_toolkit
   govuk_template
   pry-rails

--- a/app/views/errors/bad_request.html.erb
+++ b/app/views/errors/bad_request.html.erb
@@ -1,0 +1,3 @@
+<% content_for :page_title, 'Bad request (400 error) - GOV.UK' %>
+
+<h1 class="heading-xlarge">Bad request</h1>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,3 @@
+<% content_for :page_title, 'Forbidden (403 error) - GOV.UK' %>
+
+<h1 class="heading-xlarge">Forbidden</h1>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,5 @@
+<% content_for :page_title, 'Sorry, we are experiencing technical difficulties (500 error) - GOV.UK' %>
+
+<h1 class="heading-xlarge">Sorry, we are experiencing technical difficulties</h1>
+
+<p>Please try again in a few moments.</p>

--- a/app/views/errors/method_not_allowed.html.erb
+++ b/app/views/errors/method_not_allowed.html.erb
@@ -1,0 +1,3 @@
+<% content_for :page_title, 'Method not allowed (405 error) - GOV.UK' %>
+
+<h1 class="heading-xlarge">Method not allowed</h1>

--- a/app/views/errors/not_acceptable.html.erb
+++ b/app/views/errors/not_acceptable.html.erb
@@ -1,0 +1,3 @@
+<% content_for :page_title, 'Not acceptable (406 error) - GOV.UK' %>
+
+<h1 class="heading-xlarge">Not acceptable</h1>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,5 @@
+<% content_for :page_title, 'Page not found (404 error) - GOV.UK' %>
+
+<h1 class="heading-xlarge">Page not found</h1>
+
+<p>You can <%= link_to 'browse from the homepage', root_path %> to find the information you need.</p>

--- a/app/views/errors/not_implemented.html.erb
+++ b/app/views/errors/not_implemented.html.erb
@@ -1,0 +1,3 @@
+<% content_for :page_title, 'Not implemented (501 error) - GOV.UK' %>
+
+<h1 class="heading-xlarge">Not implemented</h1>

--- a/app/views/errors/unauthorized.html.erb
+++ b/app/views/errors/unauthorized.html.erb
@@ -1,0 +1,3 @@
+<% content_for :page_title, 'Unauthorized (403 error) - GOV.UK' %>
+
+<h1 class="heading-xlarge">Unauthorized</h1>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,0 +1,3 @@
+<% content_for :page_title, 'Unprocessable entity (422 error) - GOV.UK' %>
+
+<h1 class="heading-xlarge">Unprocessable entity</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
       <div class="l-column-two-thirds">
         <main role="main" id="content" tabindex="-1">
           <article role="article" class="govspeak">
-            <%= yield %>
+            <%= content_for?(:article) ? yield(:article) : yield %>
           </article>
         </main>
       </div>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,0 +1,7 @@
+<%= content_for :article do %>
+  <div class="text">
+    <%= yield %>
+  </div>
+<% end %>
+
+<%= render template: 'layouts/application' %>

--- a/config/initializers/gaffe.rb
+++ b/config/initializers/gaffe.rb
@@ -1,0 +1,1 @@
+Gaffe.enable!


### PR DESCRIPTION
- Uses [Gaffe](http://open.mirego.com/gaffe/) to handle exceptions
- Follows [content design from GOV.UK](https://github.com/alphagov/static/tree/master/app/views/root)

This will protect us if the application can start, but we may need to generate a completely static page that can be served upstream?
