### PR TITLE
Move main form from root to /register

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: 'user_profiles#new'
-  get '/', as: 'new_user_profile', to: 'user_profiles#new'
-  post '/', as: 'user_profile', to: 'user_profiles#create'
+  root to: redirect('/register')
+  get '/register', as: 'new_user_profile', to: 'user_profiles#new'
+  post '/register', as: 'user_profile', to: 'user_profiles#create'
 end

--- a/features/pages/new_user_profile.rb
+++ b/features/pages/new_user_profile.rb
@@ -1,6 +1,6 @@
 module Pages
   class NewUserProfile < SitePrism::Page
-    set_url '/'
+    set_url '/register'
 
     element :name, '.t-name'
     element :age, '.t-age'

--- a/features/pages/user_profile.rb
+++ b/features/pages/user_profile.rb
@@ -1,7 +1,7 @@
 module Pages
   class UserProfile < SitePrism::Page
-    set_url '/'
-    set_url_matcher /\/$/
+    set_url '/register'
+    set_url_matcher /\/register$/
 
     element :heading, 'h1'
   end

--- a/spec/routing/user_profiles_routing_spec.rb
+++ b/spec/routing/user_profiles_routing_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe 'Routes for Registrations', type: :routing do
   it 'routes GET / to user_profiles#new' do
-    expect(get: '/').
+    expect(get: '/register').
       to route_to(controller: 'user_profiles', action: 'new')
   end
 
   it 'routes POST / to user_profiles#create' do
-    expect(post: '/').
+    expect(post: '/register').
       to route_to(controller: 'user_profiles', action: 'create')
   end
 end


### PR DESCRIPTION
This moves the main form off of the root url and serves it on `/register`.

The GOV.UK service manual [mandates](https://www.gov.uk/service-manual/operations/operating-servicegovuk-subdomains.html#robotstxt-and-root-level-redirections) a root-level redirect to the entry point on www.gov.uk

A convenience redirect from root to `/register` exists to make dev less irritating; the GOV.UK requirement should happen in production outside of this app.
