### PR TITLE
Add Rack::Cache, cache headers on register form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ end
 
 group :production do
   gem 'foreman'
+  gem 'rack-cache'
   gem 'rails_12factor'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
     pry-rails (0.3.2)
       pry (>= 0.9.10)
     rack (1.5.2)
+    rack-cache (1.2)
+      rack (>= 0.4)
     rack-test (0.6.2)
       rack (>= 1.0)
     rack-timeout (0.1.1)
@@ -191,6 +193,7 @@ DEPENDENCIES
   newrelic_rpm
   pg
   pry-rails
+  rack-cache
   rack-timeout
   rails (= 4.1.8)
   rails_12factor

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -4,6 +4,7 @@ class UserProfilesController < ApplicationController
 
   def new
     @user_profile = UserProfile.new
+    expires_in(10.minutes, public: true)
   end
 
   def create

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,6 +45,14 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  # Use Rack::Cache
+  config.middleware.use(Rack::Cache,
+    verbose: true,
+    metastore: "heap:/",
+    entitystore: "file:#{Rails.application.root}/tmp/cache/rack/body",
+    allow_revalidate: false
+  )
+
 end
 
 Rack::Timeout.timeout = 5 # seconds

--- a/spec/controllers/user_profiles_controller_spec.rb
+++ b/spec/controllers/user_profiles_controller_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe UserProfilesController, type: :controller do
     it 'assigns a new instance of UserProfile' do
       expect(assigns(:user_profile)).to be_an_instance_of(UserProfile)
     end
+
+    it 'tells downstream servers and clients to cache the response' do
+      expect(response.headers.fetch('Cache-Control')).to eq('max-age=600, public')
+    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
- Rack::Cache middleware is added in production only
- Cache control headers for the register form are added as "cache for 10 minutes, public caching allowed"
