### PR TITLE
Serve cache-control headers for error pages

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,8 @@
+class ErrorsController < ApplicationController
+  include Gaffe::Errors
+
+  def show
+    super
+    expires_in(1.minute, public: true)
+  end
+end

--- a/config/initializers/gaffe.rb
+++ b/config/initializers/gaffe.rb
@@ -1,1 +1,5 @@
+Gaffe.configure do |config|
+  config.errors_controller = 'ErrorsController'
+end
+
 Gaffe.enable!

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe ErrorsController, type: :controller do
+  it 'is a Gaffe errors controller' do
+    expect(controller).to be_a(Gaffe::Errors)
+  end
+
+  describe 'GET show' do
+    before { routes.draw { get 'show_error' => 'errors#show' } }
+    before { get :show }
+    after { Rails.application.reload_routes! }
+
+    it 'tells downstream servers and clients to cache the response' do
+      expect(response.headers.fetch('Cache-Control')).to eq('max-age=60, public')
+    end
+  end
+end


### PR DESCRIPTION
Error pages should be cached by public downstream clients for 1 minute
