### PR TITLE
Force SSL in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,6 +53,8 @@ Rails.application.configure do
     allow_revalidate: false
   )
 
+  # Force SSL across all requests unless non-ssl requests are explicitly allowed
+  config.force_ssl = ENV['ALLOW_NON_SSL'] != 'true'
 end
 
 Rack::Timeout.timeout = 5 # seconds


### PR DESCRIPTION
Setting the ALLOW_NON_SSL environment variable to "true" will allow SSL
