### PR TITLE
Tame Rails' default verbose logging in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ end
 group :production do
   gem 'dalli'
   gem 'foreman'
+  gem 'lograge'
   gem 'rack-cache'
   gem 'rails_12factor'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,10 @@ GEM
     i18n (0.7.0)
     json (1.8.1)
     kgio (2.9.2)
+    lograge (0.3.0)
+      actionpack (>= 3)
+      activesupport (>= 3)
+      railties (>= 3)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -207,6 +211,7 @@ DEPENDENCIES
   gaffe
   govuk_frontend_toolkit
   govuk_template
+  lograge
   newrelic_rpm
   pg
   pry-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,6 @@ Rails.application.configure do
   )
 
   config.action_dispatch.rack_cache = {
-    verbose: true,
     metastore: dalli_client,
     entitystore: dalli_client,
     allow_revalidate: false
@@ -67,6 +66,9 @@ Rails.application.configure do
 
   # Prepend all log lines with the following tags.
   config.log_tags = %i( uuid )
+
+  # Tame Rails' default request logging
+  config.lograge.enabled = true
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)


### PR DESCRIPTION
Configures [lograge](https://github.com/roidrage/lograge) which logs requests to a single line.

Staged at https://ggp-register-interest-lograge.herokuapp.com/register
