### PR TITLE
Prevent "invalid byte sequence in UTF-8" errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'rails', '4.2.0'
 gem 'sass-rails', '~> 4.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn'
+gem 'utf8-cleaner'
 
 group :test do
   gem 'cucumber-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    utf8-cleaner (0.0.9)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -221,3 +222,4 @@ DEPENDENCIES
   timecop
   uglifier (>= 1.3.0)
   unicorn
+  utf8-cleaner


### PR DESCRIPTION
Removes invalid UTF-8 characters from the environment so the app doesn't choke on them.