### PR TITLE
Use our fork of travis-notify-geckoboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "bower": "*",
-    "travis-notify-geckoboard": "*"
+    "travis-notify-geckoboard": "git://github.com/guidance-guarantee-programme/travis-notify-geckoboard#item-must-be-array"
   },
   "scripts": {
     "postinstall": "./node_modules/.bin/bower install --allow-root --config.interactive=false --production"


### PR DESCRIPTION
Sibling of [pension_guidance#86](https://github.com/guidance-guarantee-programme/pension_guidance/pull/86)